### PR TITLE
Add dispatchEvent helpers

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: .NET
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/sample/src/Clock.fs
+++ b/sample/src/Clock.fs
@@ -129,7 +129,7 @@ let initEl (config: LitConfig<_>) =
 
 [<LitElement("my-clock")>]
 let Clock() =
-    let props = LitElement.init initEl
+    let _, props = LitElement.init initEl
     let hourColor = props.hourColor.Value
     let colors = props.minuteColors.Value
 

--- a/src/Lit.Test/Expect.Dom.fs
+++ b/src/Lit.Test/Expect.Dom.fs
@@ -125,6 +125,9 @@ let render_html (template: FormattableString) =
 
 [<RequireQualifiedAccess>]
 module Expect =
+    /// <summary>
+    /// Checks the text content of an element
+    /// </summary>
     let innerText (expected: string) (el: Element) =
         let el = el :?> HTMLElement
         if not(el.innerText = expected) then
@@ -132,3 +135,41 @@ module Expect =
             AssertionError.Throw("equal", actual=el.innerText, expected=expected, prefix=prefix)
 
         Expect.equal expected el.innerText
+
+    /// <summary>
+    /// Registers an event listener for a particular event name, use the action callback to make your component fire up the event.
+    /// The function will return a promise that resolves once the element dispatches the specified event
+    /// </summary>
+    /// <param name="eventName">The name of the event to listen to.</param>
+    /// <param name="action">A callback to make the element dispatch the event. this callback will be fired immediately after the listener has been registered</param>
+    /// <param name="el">Element to monitor for dispatched events.</param>
+    let toDispatch eventName (action: unit -> unit) (el: HTMLElement) =
+        Promise.create
+            (fun resolve reject ->
+                el.addEventListener (
+                    eventName,
+                    fun _ ->
+                        resolve true
+                )
+
+                action())
+
+    /// <summary>
+    /// Registers an event listener for a particular event name, use the action callback to make your component fire up the event.
+    /// The function will return a promise that resolves the detail of the custom event once the element dispatches the specified event
+    /// </summary>
+    /// <param name="eventName">The name of the event to listen to.</param>
+    /// <param name="action">A callback to make the element dispatch the event. this callback will be fired immediately after the listener has been registered</param>
+    /// <param name="el">Element to monitor for dispatched events.</param>
+    /// <returns>The detail that was provided by the custom event </returns>
+    let toDispatchCustom<'T> eventName (action: unit -> unit) (el: HTMLElement) =
+        Promise.create
+            (fun resolve reject ->
+                el.addEventListener (
+                    eventName,
+                    fun (e: Event) ->
+                        let custom = e :?> CustomEvent<'T>
+                        resolve custom.detail
+                )
+
+                action())

--- a/src/Lit/Lit.fs
+++ b/src/Lit/Lit.fs
@@ -52,8 +52,12 @@ type AsyncDirective() =
     member _.isConnected: bool = jsNative
     member _.setValue(value: obj) : unit = jsNative
 
+// LitElement should inherit HTMLElement but HTMLElement
+// is still implemented as interface in Fable.Browser
 [<Import("LitElement", "lit")>]
-type LitElementBase() =
+type LitElement() =
+    /// Access the underlying HTMLElement
+    [<Emit("$0")>] member _.el: HTMLElement = jsNative
     member _.isConnected: bool = jsNative
     member _.connectedCallback(): unit = jsNative
     member _.disconnectedCallback(): unit = jsNative

--- a/src/Lit/Lit.fs
+++ b/src/Lit/Lit.fs
@@ -52,16 +52,6 @@ type AsyncDirective() =
     member _.isConnected: bool = jsNative
     member _.setValue(value: obj) : unit = jsNative
 
-// LitElement should inherit HTMLElement but HTMLElement
-// is still implemented as interface in Fable.Browser
-[<Import("LitElement", "lit")>]
-type LitElement() =
-    /// Access the underlying HTMLElement
-    [<Emit("$0")>] member _.el: HTMLElement = jsNative
-    member _.isConnected: bool = jsNative
-    member _.connectedCallback(): unit = jsNative
-    member _.disconnectedCallback(): unit = jsNative
-
 type Part =
     interface
     end

--- a/test/LitElementTest.fs
+++ b/test/LitElementTest.fs
@@ -64,7 +64,7 @@ let DispatchEvents () =
 
     html
         $"""
-        <button @click={onClick}></button>
+        <button @click={onClick}>Click me!</button>
     """
 
 [<LitElement("fel-dispatch-custom-events")>]
@@ -76,7 +76,7 @@ let DispatchCustomEvents () =
 
     html
         $"""
-        <button @click={onClick}></button>
+        <button @click={onClick}>Click me!</button>
     """
 
 describe "LitElement" <| fun () ->
@@ -97,11 +97,11 @@ describe "LitElement" <| fun () ->
         el.shadowRoot.querySelector("#value") |> Expect.innerText "default"
         el.setAttribute("f-name", "fable")
         // wait for lit's render updates
-        do! el.updateComplete
+        do! elementUpdated el
         el.shadowRoot.querySelector("#value") |> Expect.innerText "fable"
         // update property manually
         el?fName <- "fable-2"
-        do! el.updateComplete
+        do! elementUpdated el
         el.shadowRoot.querySelector("#value") |> Expect.innerText "fable-2"
     }
 
@@ -112,11 +112,11 @@ describe "LitElement" <| fun () ->
         el.shadowRoot.querySelector("#value") |> Expect.innerText "default"
         el.setAttribute("f-name", "fable")
         // wait for lit's render updates
-        do! el.updateComplete
+        do! elementUpdated el
         el.shadowRoot.querySelector("#value") |> Expect.innerText "default"
         // update property manually
         el?fName <- "fable"
-        do! el.updateComplete
+        do! elementUpdated el
         el.shadowRoot.querySelector("#value") |> Expect.innerText "fable"
     }
 
@@ -128,7 +128,7 @@ describe "LitElement" <| fun () ->
         el.getAttribute("f-name") |> Expect.equal "default"
         el?fName <- "fable"
         // wait for lit's render updates
-        do! el.updateComplete
+        do! elementUpdated el
         // setting the property should have updated the value and the attribute
         el.shadowRoot.querySelector("#f-value") |> Expect.innerText "fable"
         el.getAttribute("f-name") |> Expect.equal "fable"
@@ -143,25 +143,20 @@ describe "LitElement" <| fun () ->
     it "Fires Events" <| fun () -> promise {
         use! el = render_html $"""<fel-dispatch-events></fel-dispatch-events>"""
         let el = el.El
-        let! didFire =
-            Expect.toDispatch
+        do!
+            Expect.dispatch
                 "fires-events"
-                (fun _ ->
-                    let btn = el.shadowRoot.querySelector "button" :?> HTMLButtonElement
-                    btn.click())
+                (fun _ -> el.shadowRoot.getButton("click").click())
                 el
-        Expect.equal true didFire
     }
 
     it "Fires Custom Events" <| fun () -> promise {
         use! el = render_html $"""<fel-dispatch-custom-events></fel-dispatch-custom-events>"""
         let el = el.El
         let! result =
-            Expect.toDispatchCustom<int>
+            Expect.dispatchCustom<int>
                 "fires-custom-events"
-                (fun _ ->
-                    let btn = el.shadowRoot.querySelector "button" :?> HTMLButtonElement
-                    btn.click())
+                (fun _ -> el.shadowRoot.getButton("click").click())
                 el
 
         Expect.equal (Some 10) result

--- a/test/LitElementTest.fs
+++ b/test/LitElementTest.fs
@@ -8,7 +8,7 @@ open WebTestRunner
 
 [<LitElement("fable-element")>]
 let MyEl () =
-    LitElement.init ()
+    let _ = LitElement.init ()
 
     html
         $"""
@@ -17,7 +17,7 @@ let MyEl () =
 
 [<LitElement("fel-attribute-changes")>]
 let AttributeChanges () =
-    let props =
+    let _, props =
         LitElement.init (fun config -> config.props <- {| fName = Prop.Of("default", attribute = "f-name") |})
 
     html
@@ -27,7 +27,7 @@ let AttributeChanges () =
 
 [<LitElement("fel-attribute-doesnt-change")>]
 let AttributeDoesntChange () =
-    let props =
+    let _, props =
         LitElement.init (fun config -> config.props <- {| fName = Prop.Of("default", attribute = "") |})
 
     html
@@ -40,7 +40,7 @@ let reverse (str: string) =
 
 [<LitElement("fel-attribute-reflects")>]
 let AttributeReflects () =
-    let props =
+    let _, props =
         LitElement.init (fun config ->
             config.props <-
                 {|


### PR DESCRIPTION
Fix #14 

@AngelMunoz Please have a look, I've added the `dispatchEvent` extensions as you suggested, with optional arguments as convenience. It'd be great if you could add a test. Notes:

- Event creation seems to be quite broken in Fable.Browser, we should fix it.
- Because `HTMLElement` is currently implement as an interface, `LitElement` cannot inherit it. As a workaround I added the `.el` property to access the HTMLElement (it just returns the casted LitElement instance). Does it look good? Should we use the full name instead `.element`?
- Also as convenience, I'm setting the common Event properties as true by default. Does it help or can it be confusing? (It should be clearly stated in the comment docs in any case)
- TODO: Comment docs
