### PR TITLE
Add ReactiveControllerbase

### DIFF
--- a/src/Lit/Lit.fs
+++ b/src/Lit/Lit.fs
@@ -3,6 +3,7 @@ namespace Lit
 open System
 open Browser.Types
 open Fable.Core
+open Lit
 
 module Types =
     type RefValue<'T> =
@@ -44,19 +45,77 @@ type TemplateResult =
 type CSSResult =
     abstract cssText: string
     abstract styleSheet: CSSStyleSheet
-
+    
 // https://lit.dev/docs/api/controllers/#ReactiveController
-type ReactiveController =
+// make an empty interface, all of the
+// reactive controller methods are optional anyways
+// and make each method implement the base
+/// Common interface for Reactive Controller Methods
+type ReactiveControllerBase = interface end
+
+type ReactiveHostConnected =
+    inherit ReactiveControllerBase
+    
+    /// <summary>
+    /// Called when the host is connected to the component tree. For custom
+    /// element hosts, this corresponds to the `connectedCallback()` lifecycle,
+    /// which is only called when the component is connected to the document.
+    /// </summary>
     abstract hostConnected: unit -> unit
+
+type ReactiveHostDisconnected =
+    inherit ReactiveControllerBase
+    /// <summary>
+    /// Called when the host is disconnected from the component tree. For custom
+    /// element hosts, this corresponds to the `disconnectedCallback()` lifecycle,
+    /// which is called the host or an ancestor component is disconnected from the
+    /// document.
+    /// </summary>
     abstract hostDisconnected: unit -> unit
+
+type ReactiveHostUpdate =
+    inherit ReactiveControllerBase
+    
+    /// <summary>
+    /// Called during the client-side host update, just before the host calls
+    /// its own update.
+    ///
+    /// Code in `update()` can depend on the DOM as it is not called in
+    /// server-side rendering.
+    /// </summary>
     abstract hostUpdate: unit -> unit
+
+type ReactiveHostUpdated =
+    inherit ReactiveControllerBase
+    
+    /// <summary>
+    /// Called after a host update, just before the host calls firstUpdated and
+    /// updated. It is not called in server-side rendering.
+    /// </summary>
     abstract hostUpdated: unit -> unit
+
+/// <summary>
+/// A Reactive Controller is an object that enables sub-component code
+/// organization and reuse by aggregating the state, behavior, and lifecycle
+/// hooks related to a single feature.
+///
+/// Controllers are added to a host component, or other object that implements
+/// the `ReactiveControllerHost` interface, via the `addController()` method.
+/// They can hook their host components's lifecycle by implementing one or more
+/// of the lifecycle callbacks, or initiate an update of the host component by
+/// calling `requestUpdate()` on the host.
+/// </summary>
+type ReactiveController =
+    inherit ReactiveHostConnected
+    inherit ReactiveHostDisconnected
+    inherit ReactiveHostUpdate
+    inherit ReactiveHostUpdated
 
 // https://lit.dev/docs/api/controllers/#ReactiveControllerHost
 type ReactiveControllerHost =
     abstract updateComplete: JS.Promise<bool>
-    abstract addController: ReactiveController -> unit
-    abstract removeController: ReactiveController -> unit
+    abstract addController: ReactiveControllerBase -> unit
+    abstract removeController: ReactiveControllerBase -> unit
     abstract requestUpdate: unit -> unit
 
 type LitBindings =

--- a/src/Lit/LitElement.fs
+++ b/src/Lit/LitElement.fs
@@ -6,6 +6,7 @@ open Fable.Core.JsInterop
 open Browser
 open Browser.Types
 open HMRTypes
+open Lit
 
 // LitElement should inherit HTMLElement but HTMLElement
 // is still implemented as interface in Fable.Browser
@@ -20,8 +21,8 @@ type LitElement() =
     member _.requestUpdate(): unit = jsNative
     /// Returns a promise that will resolve when the element has finished updating.
     member _.updateComplete: JS.Promise<unit> = jsNative
-    member _.addController(controller: ReactiveController): unit = jsNative
-    member _.removeController(controller: ReactiveController): unit = jsNative
+    member _.addController(controller: ReactiveControllerBase): unit = jsNative
+    member _.removeController(controller: ReactiveControllerBase): unit = jsNative
 
 // Compiler trick: we use a different generic type, but they both
 // refer to the same imported type
@@ -140,16 +141,16 @@ and Prop<'T> internal (defaultValue: 'T, options: obj) =
     [<Emit("$0{{ = $1}}")>]
     member _.Value with get() = defaultValue and set(_: 'T) = ()
 
-type Controller internal (init: LitElement -> ReactiveController) =
-    let mutable value = Unchecked.defaultof<ReactiveController>
+type Controller internal (init: LitElement -> ReactiveControllerBase) =
+    let mutable value = Unchecked.defaultof<ReactiveControllerBase>
     member internal _.Init(host) = value <- init host
     member _.Value = value
 
     /// Creates a controller out of an initialization function
-    static member Of<'T when 'T :> ReactiveController>(init: LitElement -> 'T) =
+    static member Of<'T when 'T :> ReactiveControllerBase>(init: LitElement -> 'T) =
         Controller<'T>(init)
 
-and Controller<'T when 'T :> ReactiveController> (init) =
+and Controller<'T when 'T :> ReactiveControllerBase> (init) =
     inherit Controller(fun host -> upcast init host)
     member _.Value = base.Value :?> 'T
 


### PR DESCRIPTION
I gave it a thought after a while, I think if we use a common base interface we won't force users to implement each method of a reactive controller
it gives the flexibility for the users to create controllers like the ones that subscribe to a global store (or even event listeners like the mouse controller)

```fsharp
type MyHalfController(host: ReactiveHost) as this =
  do
    let mutable value = 0 
    let mutable sub = None
    host.AddController(this)
  
  [<DefaultValue>]
  val Value: int 
    with get() = value

  interface ReactiveHostConnected with
    member _.hostConnected() =
      sub <-
          GlobalStore.Subscribe(fun v ->
            value <- v
            host.requestUpdate()
          )

  interface ReactiveHostDisconnected with
    member _.hostDisconnected() =
      Option.iter (fun s -> s.Dispose()) sub

```

I'm targeting your controllers branch because I'm not sure if this is a good enough change and if you want to add more to the other branch before merging the PR 
